### PR TITLE
Fix the build as far back as GHC 8.0

### DIFF
--- a/src/HaskellWorks/Data/Sv/Strict/Cursor/Internal.hs
+++ b/src/HaskellWorks/Data/Sv/Strict/Cursor/Internal.hs
@@ -7,6 +7,7 @@ module HaskellWorks.Data.Sv.Strict.Cursor.Internal where
 import Control.Monad.State
 import Data.Bits                                 (popCount)
 import Data.Char                                 (ord)
+import Data.Semigroup
 import Data.Word
 import HaskellWorks.Data.AtIndex
 import HaskellWorks.Data.Bits.BitWise


### PR DESCRIPTION
Currently this only builds on GHC 8.4 (where <> is in Prelude)
Importing Data.Semigroup makes this build as far back as 8.0