### PR TITLE
Use optimised ByteString to Vector conversion

### DIFF
--- a/src/HaskellWorks/Data/Sv/Lazy/Cursor.hs
+++ b/src/HaskellWorks/Data/Sv/Lazy/Cursor.hs
@@ -19,12 +19,12 @@ import HaskellWorks.Data.RankSelect.Base.Select1
 import HaskellWorks.Data.Sv.Internal.Bits
 import HaskellWorks.Data.Sv.Lazy.Cursor.Internal
 import HaskellWorks.Data.Sv.Lazy.Cursor.Type
+import HaskellWorks.Data.Vector.AsVector64s
 import Prelude
 
-import qualified Data.ByteString.Lazy                          as LBS
-import qualified Data.Vector                                   as DV
-import qualified HaskellWorks.Data.Sv.Internal.ByteString.Lazy as LBS
-import qualified HaskellWorks.Data.Sv.Internal.Char.Word64     as CW
+import qualified Data.ByteString.Lazy                      as LBS
+import qualified Data.Vector                               as DV
+import qualified HaskellWorks.Data.Sv.Internal.Char.Word64 as CW
 
 makeCursor :: Char -> LBS.ByteString -> SvCursor
 makeCursor delimiter lbs = SvCursor
@@ -34,7 +34,7 @@ makeCursor delimiter lbs = SvCursor
   , svCursorNewlines  = nls
   , svCursorPosition  = 0
   }
-  where ws  = LBS.toVector64Chunks 512 lbs
+  where ws  = asVector64s 64 lbs
         ibq = makeIbs CW.doubleQuote                      <$> ws
         ibn = makeIbs CW.newline                          <$> ws
         ibd = makeIbs (CW.fillWord64WithChar8 delimiter)  <$> ws

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ extra-deps:
 - bits-extra-0.0.1.1
 - hedgehog-0.5.3
 - hw-hspec-hedgehog-0.1.0.4
-- hw-prim-0.6.0.0
+- hw-prim-0.6.2.0
 - hw-rankselect-0.12.0.2
 - hw-rankselect-base-0.3.2.0
 - lazy-csv-0.5.1


### PR DESCRIPTION
### When selecting no columns
Before:

```
$ cat ~/arbornetwrks-small.csv | pv -a | time hw-sv query-lazy --source - --delimiter , --target - --out-delimiter '|' > a.txt
[ 275MiB/s]
9.16s user 1.25s system 170% cpu 6.097 total
```

After:
```
$ cat ~/arbornetwrks-small.csv | pv -a | time hw-sv query-lazy --source - --delimiter , --target - --out-delimiter '|' > b.txt
[ 376MiB/s]
7.18s user 1.19s system 187% cpu 4.473 total
```

### When selecting two columns
Before:
```
$ cat ~/arbornetwrks-small.csv | pv -a | time hw-sv query-lazy --source - --column 0 --column 1 --delimiter , --target - --out-delimiter '|' > a.txt
[ 121MiB/s]
23.15s user 3.35s system 192% cpu 13.757 total
```

After:
```
$ cat sample.csv | pv -a | time hw-sv query-lazy --source - --column 0 --column 1 --delimiter , --target - --out-delimiter '|' > b.txt
[ 147MiB/s]
19.63s user 3.03s system 198% cpu 11.408 total
```