### PR TITLE
Mutable vector based index construction

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -153,6 +153,7 @@ makeBenchMkInterestBits = do
     [ env (IO.mmapFromForeignRegion file) $ \(v :: DVS.Vector Word64) -> bgroup "Loading lazy byte string into Word64s" $ mempty
       <> [bench ("mkIbVector                  with sum" <> file) (whnf (DVS.foldr (+) 0 . SVS.mkIbVector        '|') v)]
       <> [bench ("mkDsvInterestBitsByWord64s  with sum" <> file) (whnf (DVS.foldr (+) 0 . SVS.mkDsvInterestBits '|') v)]
+      <> [bench ("makeIndexes                 with sum" <> file) (whnf (DVS.foldr (+) 0 . fst . SVS.makeIndexes '|') v)]
     ]
   return (join benchmarks)
 

--- a/src/HaskellWorks/Data/Sv/Lazy/Cursor/Internal.hs
+++ b/src/HaskellWorks/Data/Sv/Lazy/Cursor/Internal.hs
@@ -90,4 +90,3 @@ makeCummulativePopCount = go 0
         go c (v:vs) = let (u, c') = makeCummulativePopCount2 c v in u:go c' vs
         go _ []     = []
 {-# INLINE makeCummulativePopCount #-}
-

--- a/src/HaskellWorks/Data/Sv/Strict/Cursor/Internal.hs
+++ b/src/HaskellWorks/Data/Sv/Strict/Cursor/Internal.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE ExplicitForAll   #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ExplicitForAll      #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module HaskellWorks.Data.Sv.Strict.Cursor.Internal where
 
+import Control.Monad.ST
 import Data.Bits                                 (popCount)
 import Data.Semigroup
 import Data.Word
@@ -18,10 +20,116 @@ import HaskellWorks.Data.Sv.Strict.Cursor.Type
 import Prelude
 
 import qualified Data.Vector.Storable                      as DVS
+import qualified Data.Vector.Storable.Mutable              as DVSM
 import qualified HaskellWorks.Data.Length                  as V
 import qualified HaskellWorks.Data.Sv.Internal.Char.Word64 as CW
 
 {-# ANN module ("HLint: ignore Reduce duplication"  :: String) #-}
+
+makeIndexes :: Char -> DVS.Vector Word64 -> (DVS.Vector Word64, DVS.Vector Word64)
+makeIndexes delimiter ws = case DVS.createT $ makeIndexes' CW.doubleQuote CW.newline (fillWord64WithChar8 delimiter) ws of
+  [markers, newlines] -> (markers, newlines)
+  _                   -> error "This should not happen"
+
+makeIndexes' :: forall s.
+     Word64
+  -> Word64
+  -> Word64
+  -> DVS.Vector Word64
+  -> ST s [DVS.MVector s Word64]
+makeIndexes' rdqs rnls rdls ws = do
+  (markers  :: DVSM.MVector s Word64) <- DVSM.unsafeNew ((DVS.length ws + 7) `div` 8)
+  (newlines :: DVSM.MVector s Word64) <- DVSM.unsafeNew ((DVS.length ws + 7) `div` 8)
+  go markers newlines 0 0
+  return [markers, newlines]
+  where go :: DVSM.MVector s Word64 -> DVSM.MVector s Word64 -> Position -> Count -> ST s ()
+        go markers newlines wsi numQuotes = let ui = wsi `div` 8 in if wsi >= 0 && wsi + 8 <= end ws
+          then do
+            let w0    = ws !!!  wsi
+            let w0Dqs = testWord8s (w0 .^. rdqs)
+            let w0Nls = testWord8s (w0 .^. rnls)
+            let w0Dls = testWord8s (w0 .^. rdls)
+            let w1    = ws !!! (wsi + 1)
+            let w1Dqs = testWord8s (w1 .^. rdqs)
+            let w1Nls = testWord8s (w1 .^. rnls)
+            let w1Dls = testWord8s (w1 .^. rdls)
+            let w2    = ws !!! (wsi + 2)
+            let w2Dqs = testWord8s (w2 .^. rdqs)
+            let w2Nls = testWord8s (w2 .^. rnls)
+            let w2Dls = testWord8s (w2 .^. rdls)
+            let w3    = ws !!! (wsi + 3)
+            let w3Dqs = testWord8s (w3 .^. rdqs)
+            let w3Nls = testWord8s (w3 .^. rnls)
+            let w3Dls = testWord8s (w3 .^. rdls)
+            let w4    = ws !!! (wsi + 4)
+            let w4Dqs = testWord8s (w4 .^. rdqs)
+            let w4Nls = testWord8s (w4 .^. rnls)
+            let w4Dls = testWord8s (w4 .^. rdls)
+            let w5    = ws !!! (wsi + 5)
+            let w5Dqs = testWord8s (w5 .^. rdqs)
+            let w5Nls = testWord8s (w5 .^. rnls)
+            let w5Dls = testWord8s (w5 .^. rdls)
+            let w6    = ws !!! (wsi + 6)
+            let w6Dqs = testWord8s (w6 .^. rdqs)
+            let w6Nls = testWord8s (w6 .^. rnls)
+            let w6Dls = testWord8s (w6 .^. rdls)
+            let w7    = ws !!! (wsi + 7)
+            let w7Dqs = testWord8s (w7 .^. rdqs)
+            let w7Nls = testWord8s (w7 .^. rnls)
+            let w7Dls = testWord8s (w7 .^. rdls)
+            let wDqs  = (w7Dqs  .<. 56) .|. (w6Dqs .<. 48) .|. (w5Dqs .<. 40) .|. (w4Dqs .<. 32) .|. (w3Dqs .<. 24) .|. (w2Dqs .<. 16) .|. (w1Dqs .<. 8) .|. w0Dqs
+            let wNls  = (w7Nls  .<. 56) .|. (w6Nls .<. 48) .|. (w5Nls .<. 40) .|. (w4Nls .<. 32) .|. (w3Nls .<. 24) .|. (w2Nls .<. 16) .|. (w1Nls .<. 8) .|. w0Nls
+            let wDls  = (w7Dls  .<. 56) .|. (w6Dls .<. 48) .|. (w5Dls .<. 40) .|. (w4Dls .<. 32) .|. (w3Dls .<. 24) .|. (w2Dls .<. 16) .|. (w1Dls .<. 8) .|. w0Dls
+            let numWordQuotes = comp wDqs
+            let wMask = toggle64 numQuotes numWordQuotes
+            let newNumQuotes = numQuotes + fromIntegral (popCount numWordQuotes)
+            DVSM.unsafeWrite markers  (fromIntegral ui) (comp (wNls .&. wDls) .&. wMask)
+            DVSM.unsafeWrite newlines (fromIntegral ui) (comp  wNls           .&. wMask)
+            go markers newlines (wsi + 8) newNumQuotes
+
+          else do
+            let w0    = atIndexOr 0 ws  wsi
+            let w0Dqs = testWord8s (w0 .^. rdqs)
+            let w0Nls = testWord8s (w0 .^. rnls)
+            let w0Dls = testWord8s (w0 .^. rdls)
+            let w1    = atIndexOr 0 ws (wsi + 1)
+            let w1Dqs = testWord8s (w1 .^. rdqs)
+            let w1Nls = testWord8s (w1 .^. rnls)
+            let w1Dls = testWord8s (w1 .^. rdls)
+            let w2    = atIndexOr 0 ws (wsi + 2)
+            let w2Dqs = testWord8s (w2 .^. rdqs)
+            let w2Nls = testWord8s (w2 .^. rnls)
+            let w2Dls = testWord8s (w2 .^. rdls)
+            let w3    = atIndexOr 0 ws (wsi + 3)
+            let w3Dqs = testWord8s (w3 .^. rdqs)
+            let w3Nls = testWord8s (w3 .^. rnls)
+            let w3Dls = testWord8s (w3 .^. rdls)
+            let w4    = atIndexOr 0 ws (wsi + 4)
+            let w4Dqs = testWord8s (w4 .^. rdqs)
+            let w4Nls = testWord8s (w4 .^. rnls)
+            let w4Dls = testWord8s (w4 .^. rdls)
+            let w5    = atIndexOr 0 ws (wsi + 5)
+            let w5Dqs = testWord8s (w5 .^. rdqs)
+            let w5Nls = testWord8s (w5 .^. rnls)
+            let w5Dls = testWord8s (w5 .^. rdls)
+            let w6    = atIndexOr 0 ws (wsi + 6)
+            let w6Dqs = testWord8s (w6 .^. rdqs)
+            let w6Nls = testWord8s (w6 .^. rnls)
+            let w6Dls = testWord8s (w6 .^. rdls)
+            let w7    = atIndexOr 0 ws (wsi + 7)
+            let w7Dqs = testWord8s (w7 .^. rdqs)
+            let w7Nls = testWord8s (w7 .^. rnls)
+            let w7Dls = testWord8s (w7 .^. rdls)
+            let wDqs  = (w7Dqs  .<. 56) .|. (w6Dqs .<. 48) .|. (w5Dqs .<. 40) .|. (w4Dqs .<. 32) .|. (w3Dqs .<. 24) .|. (w2Dqs .<. 16) .|. (w1Dqs .<. 8) .|. w0Dqs
+            let wNls  = (w7Nls  .<. 56) .|. (w6Nls .<. 48) .|. (w5Nls .<. 40) .|. (w4Nls .<. 32) .|. (w3Nls .<. 24) .|. (w2Nls .<. 16) .|. (w1Nls .<. 8) .|. w0Nls
+            let wDls  = (w7Dls  .<. 56) .|. (w6Dls .<. 48) .|. (w5Dls .<. 40) .|. (w4Dls .<. 32) .|. (w3Dls .<. 24) .|. (w2Dls .<. 16) .|. (w1Dls .<. 8) .|. w0Dls
+            let numWordQuotes = comp wDqs
+            let wMask = toggle64 numQuotes numWordQuotes
+            DVSM.unsafeWrite markers  (fromIntegral ui) (comp (wNls .&. wDls) .&. wMask)
+            DVSM.unsafeWrite newlines (fromIntegral ui) (comp  wNls           .&. wMask)
+
+
+
 
 mkDsvInterestBits :: Char -> DVS.Vector Word64 -> DVS.Vector Word64
 mkDsvInterestBits delimiter v = DVS.fromListN ((DVS.length v + 7) `div` 8) $ mkDsvInterestBitsByWord64s


### PR DESCRIPTION
`makeIndexes` is consistently faster than both `mkIbVector` and `mkDsvInterestBitsByWord64s`

```
benchmarking Loading lazy byte string into Word64s/mkIbVector                  with sumdata/bench/data-0001000.csv
time                 142.4 μs   (141.8 μs .. 143.0 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 142.8 μs   (142.3 μs .. 143.5 μs)
std dev              2.050 μs   (1.607 μs .. 3.093 μs)

benchmarking Loading lazy byte string into Word64s/mkDsvInterestBitsByWord64s  with sumdata/bench/data-0001000.csv
time                 389.2 μs   (387.2 μs .. 391.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 390.5 μs   (389.3 μs .. 392.0 μs)
std dev              4.251 μs   (3.481 μs .. 5.292 μs)

benchmarking Loading lazy byte string into Word64s/makeIndexes                 with sumdata/bench/data-0001000.csv
time                 106.8 μs   (106.2 μs .. 107.5 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 107.0 μs   (106.6 μs .. 107.6 μs)
std dev              1.734 μs   (1.223 μs .. 2.619 μs)
variance introduced by outliers: 11% (moderately inflated)

benchmarking Loading lazy byte string into Word64s/mkIbVector                  with sumdata/bench/data-0010000.csv
time                 474.0 μs   (470.8 μs .. 476.9 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 478.9 μs   (476.1 μs .. 482.8 μs)
std dev              11.37 μs   (8.775 μs .. 17.12 μs)
variance introduced by outliers: 16% (moderately inflated)

benchmarking Loading lazy byte string into Word64s/mkDsvInterestBitsByWord64s  with sumdata/bench/data-0010000.csv
time                 1.288 ms   (1.282 ms .. 1.295 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.290 ms   (1.280 ms .. 1.301 ms)
std dev              35.19 μs   (22.90 μs .. 58.85 μs)
variance introduced by outliers: 16% (moderately inflated)

benchmarking Loading lazy byte string into Word64s/makeIndexes                 with sumdata/bench/data-0010000.csv
time                 356.4 μs   (355.4 μs .. 357.5 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 354.9 μs   (351.6 μs .. 356.6 μs)
std dev              7.905 μs   (5.641 μs .. 11.97 μs)
variance introduced by outliers: 15% (moderately inflated)

benchmarking Loading lazy byte string into Word64s/mkIbVector                  with sumdata/bench/data-0100000.csv
time                 5.194 ms   (5.120 ms .. 5.250 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 5.170 ms   (5.144 ms .. 5.202 ms)
std dev              91.88 μs   (74.61 μs .. 114.8 μs)

benchmarking Loading lazy byte string into Word64s/mkDsvInterestBitsByWord64s  with sumdata/bench/data-0100000.csv
time                 13.11 ms   (13.02 ms .. 13.18 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 13.12 ms   (13.06 ms .. 13.25 ms)
std dev              211.1 μs   (104.2 μs .. 339.3 μs)

benchmarking Loading lazy byte string into Word64s/makeIndexes                 with sumdata/bench/data-0100000.csv
time                 3.954 ms   (3.919 ms .. 3.989 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 3.969 ms   (3.953 ms .. 3.989 ms)
std dev              58.93 μs   (42.53 μs .. 91.53 μs)
```