### PR TITLE
Make use of newlines index for performance gains

### DIFF
--- a/app/App/Commands/Options/Type.hs
+++ b/app/App/Commands/Options/Type.hs
@@ -16,6 +16,7 @@ data QueryOptions = QueryOptions
   , _queryOptionsFilePath         :: FilePath
   , _queryOptionsOutputFilePath   :: FilePath
   , _queryOptionsDelimiter        :: Char
+  , _queryOptionsOutDelimiter     :: Char
   , _queryOptionsOutputBufferSize :: Maybe Int
   } deriving (Eq, Show)
 

--- a/src/HaskellWorks/Data/Sv/Strict/Cursor.hs
+++ b/src/HaskellWorks/Data/Sv/Strict/Cursor.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE MultiWayIf          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 

--- a/weigh/Space.hs
+++ b/weigh/Space.hs
@@ -11,6 +11,8 @@ import qualified Data.Csv                            as CSV
 import qualified Data.Vector                         as DV
 import qualified HaskellWorks.Data.Sv.Strict1.Cursor as SVS
 
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
 repeatedly :: (a -> Maybe a) -> a -> [a]
 repeatedly f a = a:case f a of
   Just b  -> repeatedly f b


### PR DESCRIPTION
Twice before:

```
$ time hw-sv query --source ~/arbornetwrks_v888_20180503.csv --create-index --column 0 --column 1 --delimiter , --target - > a.txt
149.06s user 45.39s system 99% cpu 3:15.98 total
```

Before:

```
$ time hw-sv query --source ~/arbornetwrks_v888_20180503.csv --create-index --column 0 --column 1 --delimiter , --target - > a.txt
147.67s user 47.63s system 91% cpu 3:34.41 total
```

The reason it is slower is because it is building an additional newlines index, which is currently not being used.

After:

```
$ time hw-sv query --source ~/arbornetwrks_v888_20180503.csv --create-index --column 0 --column 1 --delimiter , --target - --out-delimiter , > a.txt
374.33s user 51.32s system 272% cpu 2:36.47 total
```