### PR TITLE
Organise commands

### DIFF
--- a/app/App/Commands.hs
+++ b/app/App/Commands.hs
@@ -8,10 +8,19 @@ import App.Commands.QueryLazy
 import Data.Semigroup           ((<>))
 import Options.Applicative
 
-cmdOpts :: Parser (IO ())
-cmdOpts = subparser $ mempty
-  <>  cmdCat
+commands :: Parser (IO ())
+commands = commandsGeneral <|> commandsDebugging
+
+commandsGeneral :: Parser (IO ())
+commandsGeneral = subparser $ mempty
+  <>  commandGroup "Commands:"
   <>  cmdCreateIndex
-  <>  cmdGenerate
   <>  cmdQuery
   <>  cmdQueryLazy
+
+commandsDebugging :: Parser (IO ())
+commandsDebugging = subparser $ mempty
+  <>  commandGroup "Debugging commands:"
+  <>  cmdCat
+  <>  cmdGenerate
+  <>  hidden

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,4 +8,4 @@ import Options.Applicative
 main :: IO ()
 main = join $ customExecParser
   (prefs $ showHelpOnEmpty <> showHelpOnError)
-  (info (cmdOpts <**> helper) idm)
+  (info (commands <**> helper) idm)


### PR DESCRIPTION
```
$ hw-sv
Usage: hw-sv COMMAND

Available options:
  -h,--help                Show this help text

Commands:
  create-index
  query
  query-lazy

Debugging commands:
  cat
  generate
```